### PR TITLE
Don't call get_settings upon import

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/core/config/logging.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/core/config/logging.py
@@ -1,26 +1,27 @@
 {% if cookiecutter.settings_management == 'y' %}from {{cookiecutter.app_name}}.core.config.settings import get_settings
 
 {% endif -%}
-logging_config = {
-    "version": 1,
-    "disable_existing_loggers": True,
-    "formatters": {
-        "standard": {
-            "format": "%(levelname)s: [%(name)s:%(funcName)s:%(lineno)s] %(message)s",
+def get_logging_config() -> dict:
+    return {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "standard": {
+                "format": "%(levelname)s: [%(name)s:%(funcName)s:%(lineno)s] %(message)s",
+            },
         },
-    },
-    "handlers": {
-        "console": {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": "standard",
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+            },
         },
-    },
-    "loggers": {
-        "{{cookiecutter.app_name}}": {
-            "handlers": ["console"],
-            "propagate": False,
-            "level": {% if cookiecutter.settings_management == 'y' %}"DEBUG" if get_settings().debug is True else "INFO"{% else %}"INFO"{% endif %},
+        "loggers": {
+            "{{cookiecutter.app_name}}": {
+                "handlers": ["console"],
+                "propagate": False,
+                "level": {% if cookiecutter.settings_management == 'y' %}"DEBUG" if get_settings().debug is True else "INFO"{% else %}"INFO"{% endif %},
+            },
         },
-    },
-}
+    }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/main.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/main.py
@@ -2,12 +2,12 @@
 {% endif %}
 import typer{% if cookiecutter.logging_config == 'y' %}
 
-from {{cookiecutter.app_name}}.core.config.logging import logging_config{% endif %}
+from {{cookiecutter.app_name}}.core.config.logging import get_logging_config{% endif %}
 
 
 def main():{% if cookiecutter.logging_config == 'y' %}
     # Configuring Python logging.
-    logging.config.dictConfig(logging_config)
+    logging.config.dictConfig(get_logging_config())
 {% endif %}
     typer.echo(
         typer.style(


### PR DESCRIPTION
during tests `get_settings` will fail to be imported since we haven't overwritten the env variables by then. So don't run the function until needed. Spawned from https://github.com/HummingbirdTechGroup/hb-crop-row-angle-detection/pull/2#discussion_r761883203