### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ is a reference of them:
   `image_analysis`.
 - **`project_short_description`**: Brief description of what is the purpose of
   the application.
+- **`agreena_gh_team`**: The name of the Github team that will own the repository.
+  This sets up a `CODEOWNERS` file which sets the given team as the default 
+  reviewers. They must be given relevant permissions over the repository.
+  The team will be appended to `@Agreena-ApS/`.
 - **`settings_management`**: Wheter a Pydantic settings management class should
   be generated (`y`) or not (`n`) as part of the Python codebase bootstrap.
   Defaults to `y`.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
     "app_name": "{{ cookiecutter.project_slug.replace('service', '').replace('hb', '').lstrip('-').rstrip('-').replace('-', '_') }}",
     "project_short_description": "Please add a short description of the Python app...",
+    "agreena_gh_team": "data-engineering",
     "settings_management": "y",
     "logging_config": "y",
     "docker_enabled": "y",

--- a/{{cookiecutter.project_slug}}/CODEOWNERS
+++ b/{{cookiecutter.project_slug}}/CODEOWNERS
@@ -1,0 +1,2 @@
+# Set this team as global PR reviewers
+@Agreena-ApS/{{cookiecutter.agreena_gh_team}}


### PR DESCRIPTION
Take the Agreena Github team as an additional input and add it to a `CODEOWNERS` file. This defines the owners and PR reviewers for the repository