### PR TITLE
Implement installable package and pinned requirements options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ for the project, by default:
 - A default [pytest](https://docs.pytest.org/en/latest/) `conftest.py` fixtures
   file that helps to override base settings, in case the user opted to have 
   them.
-- Basic [pip requirements files](https://pip.pypa.io/en/latest/user_guide/#requirements-files)
-  inside a `requirements` directory.
+- Basic [frozen pip requirements files](https://pip.pypa.io/en/latest/user_guide/#requirements-files)
+  inside a `requirements` directory and a method for generating these with [pip-tools](https://pip-tools.readthedocs.io/en/latest/).
 - Configuration for a Code QA / linter tool, which can be chosen by the 
   user. [Pylint](https://pylint.org/), [Flake8](https://flake8.pycqa.org/en/latest/),
   and [Ruff](https://beta.ruff.rs/docs/) are the ones currently supported.

--- a/README.md
+++ b/README.md
@@ -24,14 +24,19 @@ for the project, by default:
 
 - A `main.py` module that could serve as an entrypoint for your app, or also
   otherwise as a quick, easy to substitute example.
+  An optional `setup.cfg` packaging metadata file and `pyproject.toml` build
+  specification. This allows the application to be installed as a Python 
+  package.
 - Minimum app layout including by default a project settings management class
   based on [Pydantic](https://pydantic-docs.helpmanual.io/) and a basic Python
   logging configuration dictionary.
 - A default [pytest](https://docs.pytest.org/en/latest/) `conftest.py` fixtures
   file that helps to override base settings, in case the user opted to have 
   them.
-- Basic [frozen pip requirements files](https://pip.pypa.io/en/latest/user_guide/#requirements-files)
-  inside a `requirements` directory and a method for generating these with [pip-tools](https://pip-tools.readthedocs.io/en/latest/).
+  Basic [frozen pip requirements files](https://pip.pypa.io/en/latest/user_guide/#requirements-files)
+  inside a `requirements` directory. If a Python package is requested and the user
+  specifies requirements should be frozen, a method for generating these with 
+  [pip-tools](https://pip-tools.readthedocs.io/en/latest/) is also included.
 - Configuration for a Code QA / linter tool, which can be chosen by the 
   user. [Pylint](https://pylint.org/), [Flake8](https://flake8.pycqa.org/en/latest/),
   and [Ruff](https://beta.ruff.rs/docs/) are the ones currently supported.
@@ -93,15 +98,21 @@ is a reference of them:
   This sets up a `CODEOWNERS` file which sets the given team as the default 
   reviewers. They must be given relevant permissions over the repository.
   The team will be appended to `@Agreena-ApS/`.
-- **`settings_management`**: Wheter a Pydantic settings management class should
+- **`python_package`**: Whether to include Python packaging metadata files (`y`)
+  or not (`n`). This will allow the application to be installed as a Python 
+  package with `pip`. Defaults to `y`. 
+- **`settings_management`**: Whether a Pydantic settings management class should
   be generated (`y`) or not (`n`) as part of the Python codebase bootstrap.
   Defaults to `y`.
-- **`logging_config`**: Wheter a basic Python logging configuration dictionary
+- **`logging_config`**: Whether a basic Python logging configuration dictionary
   should be generated (`y`) or not (`n`) as part of the Python codebase 
   bootstrap. Defaults to `y`.
-- **`docker_enabled`**: Wheter a basic Dockerfile to create a container image
+- **`docker_enabled`**: Whether a basic Dockerfile to create a container image
   for the project should be generated (`y`) or not (`n`). Defaults to `y`.
-- **`circle_ci_config`**: Wheter a Circle CI YAML configuration file should be
+- **`freeze_requirements`**: Whether tools to pin requirements files with
+  `pip-tools` should be included (`y`) or not (`n`). Defaults to `y`. 
+  This is only used if `python_package` is set to `y`.
+- **`circle_ci_config`**: Whether a Circle CI YAML configuration file should be
   generated or not, and what workflow should have. There are 3 options here:
   1. `trunk`: Generate CircleCI configuration, with "trunk branch" development
   mode. Your Git PRs are merged into `develop` branch and then deployed to

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,9 +4,11 @@
     "app_name": "{{ cookiecutter.project_slug.replace('service', '').replace('hb', '').lstrip('-').rstrip('-').replace('-', '_') }}",
     "project_short_description": "Please add a short description of the Python app...",
     "agreena_gh_team": "data-engineering",
+    "python_package": "y",
     "settings_management": "y",
     "logging_config": "y",
     "docker_enabled": "y",
+    "freeze_requirements": "y",
     "circle_ci_config": ["trunk", "CI-CD", "none"],
     "code_qa": ["pylint", "flake8", "ruff"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def check_python_package_files(settings: Settings) -> None:
     creation of package metadata files.
     This also affects files relating to `pip-tools` freezing requirements.
     """
-    if settings.logging_config is False:
+    if settings.python_package is False:
         os.remove(os.path.join(os.getcwd(), "setup.cfg"))
 
 
@@ -126,3 +126,4 @@ if __name__ == "__main__":
     check_docker(settings)
     check_circleci(settings)
     check_code_qa(settings)
+    check_python_package_files(settings)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,6 +9,7 @@ class Settings:
     settings_management: bool
     logging_config: bool
     docker_enabled: bool
+    python_package: bool
     circle_ci_config: str
     code_qa: str
     linters: List[str] = field(init=False, default_factory=list)
@@ -69,6 +70,16 @@ def check_core_module(settings: Settings) -> None:
         shutil.rmtree(os.path.join(os.getcwd(), "{{cookiecutter.app_name}}", "core"))
 
 
+def check_python_package_files(settings: Settings) -> None:
+    """
+    Opting to not produce a Python installable package will dismiss the
+    creation of package metadata files.
+    This also affects files relating to `pip-tools` freezing requirements.
+    """
+    if settings.logging_config is False:
+        os.remove(os.path.join(os.getcwd(), "setup.cfg"))
+
+
 def check_docker(settings: Settings) -> None:
     """
     `docker_enabled` creates `Dockerfile` and `.dockerignore`. Disabling it
@@ -104,6 +115,7 @@ if __name__ == "__main__":
         settings_management="{{cookiecutter.settings_management}}" == "y",
         logging_config="{{cookiecutter.logging_config}}" == "y",
         docker_enabled="{{cookiecutter.docker_enabled}}" == "y",
+        python_package="{{cookiecutter.python_package}}" == "y",
         circle_ci_config="{{cookiecutter.circle_ci_config}}",
         code_qa="{{cookiecutter.code_qa}}",
     )

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -61,9 +61,31 @@ python {{cookiecutter.app_name}}/main.py
 
 ```bash
 export PYTHONPATH="{$PYTHONPATH}:/absolute/path/to/{{cookiecutter.project_slug}}"
-```   
+```
 
+{% if cookiecutter.python_package == 'y' -%}
+### Package Installation
 
+The application can be installed as a package with `pip`. 
+
+```bash
+pip install .
+```
+
+This will allow the module to be imported directly in a Python environment:
+
+```python
+import {{ cookiecutter.app_name }}
+```
+
+To install the package in development mode, which will include the development 
+requirements and modify the installation as files are changed, run:
+
+```bash
+pip install -e .[dev]
+```
+
+{% endif -%}
 ## Contributing
 
 Before starting to contribute to {{cookiecutter.project_name}}, please install `pre-commit` to make
@@ -75,3 +97,33 @@ sure your changes get checked for style and standards before committing them to 
 If you are running the Docker setup, please install it with `pip` in your host machine:
 
     $ pip install pre-commit
+
+{% if cookiecutter.python_package == 'y' and cookiecutter.freeze_requirements == 'y' -%}
+### Adding new Python packages
+
+This project uses [pip-tools](https://pip-tools.readthedocs.io/en/latest/) to maintain the tree of
+dependencies. Please make sure you install the `pip-tools` package before proceeding.
+
+If you need to add any new Python package to the project, both for production codebase or for tests,
+you must proceed as follows:
+
+1. Specify your package in the `setup.cfg` file. Should the package be only used in local developer
+   environment (this includes CI environments), please add it to the `[options.extras_require]`
+   under the `dev` section.
+2. Once you are done with this, trigger the next command so the dependencies tree is resolved:
+   ```bash
+   pip-compile --output-file=requirements/base.txt setup.cfg
+   ```
+   Or, in case the dependency belongs to development/test environments:
+   ```bash
+   pip-compile --extra=dev --output-file=requirements/development.txt setup.cfg
+   ```
+3. You can now install your package locally, by triggering the command:
+   ```bash
+   pip-sync requirements/development.txt
+   ```
+4. :warning: Commit **all** the files you have modified.
+
+In order to **update** existing dependencies to newer versions, please consult the pip-tools
+[documentation](https://pip-tools.readthedocs.io/en/latest/#updating-requirements).
+{% endif %}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,3 +1,9 @@
+{%- if cookiecutter.python_package == 'y' -%}
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+{% endif -%}
 [tool.black]
 line-length = 100
 target-version = ['py311']

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,0 +1,43 @@
+[metadata]
+name = {{ cookiecutter.project_slug }}
+version = 0.0.1
+author = Agreena Technology Limited
+author_email = {{ cookiecutter.agreena_gh_team }}@agreena.com
+license = Proprietary
+description =
+    {{ cookiecutter.project_short_description }}
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/Agreena-ApS/{{ cookiecutter.project_slug }}
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    License :: Other/Proprietary License
+    Operating System :: POSIX :: Linux
+
+[options]
+packages = find:
+include_package_data = true
+python_requires = >=3.10
+install_requires =
+    pydantic[dotenv]
+
+[options.extras_require]
+dev =
+    black
+    {% if cookiecutter.code_qa == 'flake8' %}flake8
+    {% endif -%}
+    mypy
+    {% if cookiecutter.freeze_requirements == 'y' %}pip-tools>=7.0
+    {% endif -%}
+    pre-commit
+    {% if cookiecutter.code_qa == 'pylint' %}pylint
+    {% endif -%}
+    pytest
+    pytest-cov
+    {% if cookiecutter.code_qa == 'ruff' %}ruff
+{% endif %}
+[options.packages.find]
+exclude =
+    tests


### PR DESCRIPTION
Include a `setup.cfg` and `pyproject.toml` build section to allow the application to be installed as a Python package.
Include `pip-tools` to pin requirements when deploying as a container. 
_Pinned requirements are currently tied to a Python package due to the use of `setup.cfg` as the requirements source._