### PR TITLE
Only include CircleCI validation hook if using CircleCI

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -35,7 +35,9 @@ repos:
         language: system
         types: [python]
 {%- endif %}
+{%- if cookiecutter.circle_ci_config != 'none' %}
   - repo: https://github.com/AleksaC/circleci-cli-py
     rev: v0.1.27660
     hooks:
       - id: circle-ci-validator
+{% endif %}


### PR DESCRIPTION
Only include CircleCI validation hook if using CircleCI. Otherwise, an error will be raised in `pre-commit` when trying to validate a file that does not exist.