### PR TITLE
Chore/fix pytest config syntax

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
             pytest \
               --verbose \
               --junitxml=test-results/junit.xml \
-              --cov=user_management \
+              --cov={{cookiecutter.app_name}} \
               --cov-report=html:coverage-results/coverage.html
       - store_test_results:
           path: test-results

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -16,6 +16,6 @@ line-length = 100
 target-version = "py311"
 {% endif %}
 
-[tool.pytest]
+[tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "info"


### PR DESCRIPTION
## Description

Use `pytest.ini_options` in pytest config.
Remove untemplated app name in coverage CI task.

## How Has This Been Tested?

N/A

## Checklist:

- [ ] Relevant README documentation has been updated
