### PR TITLE
Test job remove pytest recording block-network parameter fix

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -89,11 +89,11 @@ workflows:
       - python/test:
           name: test
           executor: tests-runner
+          pkg-manager: pip
           pip-dependency-file: requirements/development.txt
           cov: {{cookiecutter.app_name}}
           test-tool-args: |
-            --verbose \
-            --block-network
+            --verbose
 
       # Staging
       - push-docker-image:


### PR DESCRIPTION
## Description

<!-- Summary of the changes and the related issue. -->
Remove `block-network` parameter that was working only with pytest-recording as dependency but not all python apps use it.

## How Has This Been Tested?

<!-- Remove this section if tests are not relevant. For example, for a documentation change.
https://github.com/Agreena-ApS/farmer-onboarding-ingestion-task/pull/4

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
-->

## Checklist:

- [ ] Relevant README documentation has been updated
