### PR TITLE
[RS-724] Fix ci workflow precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cookiecutter Python App
 
-Basic template for Python applications at Agreena, using 
+Basic template for Python applications at Agreena, using
 [Cookiecutter](https://github.com/cookiecutter/cookiecutter).
 
 
@@ -8,12 +8,12 @@ Basic template for Python applications at Agreena, using
 
 This is a template to quickly bootstrap Python application projects. The goal
 is to get the application base layout and configuration sorted out from the
-beginning, uniformizing the different Python based projects at Agreena so they 
-look familiar to the engineers and become predictable for DevOps, saving time 
+beginning, uniformizing the different Python based projects at Agreena so they
+look familiar to the engineers and become predictable for DevOps, saving time
 and making people's life (hopefully) easier.
 
-At the same time, this template pretends to be only a base point for the 
-application development, giving freedom to developers to decide about codebase 
+At the same time, this template pretends to be only a base point for the
+application development, giving freedom to developers to decide about codebase
 layout and architecture.
 
 
@@ -25,22 +25,22 @@ for the project, by default:
 - A `main.py` module that could serve as an entrypoint for your app, or also
   otherwise as a quick, easy to substitute example.
   An optional `setup.cfg` packaging metadata file and `pyproject.toml` build
-  specification. This allows the application to be installed as a Python 
+  specification. This allows the application to be installed as a Python
   package.
 - Minimum app layout including by default a project settings management class
   based on [Pydantic](https://pydantic-docs.helpmanual.io/) and a basic Python
   logging configuration dictionary.
 - A default [pytest](https://docs.pytest.org/en/latest/) `conftest.py` fixtures
-  file that helps to override base settings, in case the user opted to have 
+  file that helps to override base settings, in case the user opted to have
   them.
   Basic [frozen pip requirements files](https://pip.pypa.io/en/latest/user_guide/#requirements-files)
   inside a `requirements` directory. If a Python package is requested and the user
-  specifies requirements should be frozen, a method for generating these with 
+  specifies requirements should be frozen, a method for generating these with
   [pip-tools](https://pip-tools.readthedocs.io/en/latest/) is also included.
-- Configuration for a Code QA / linter tool, which can be chosen by the 
+- Configuration for a Code QA / linter tool, which can be chosen by the
   user. [Pylint](https://pylint.org/), [Flake8](https://flake8.pycqa.org/en/latest/),
   and [Ruff](https://beta.ruff.rs/docs/) are the ones currently supported.
-- [Mypy](http://mypy-lang.org/) configuration file, to help on static type 
+- [Mypy](http://mypy-lang.org/) configuration file, to help on static type
   checking.
 - [pre-commit](https://pre-commit.com/) configuration file, to perform all
   code styling and QA checks before committing new code.
@@ -86,33 +86,33 @@ is a reference of them:
   is mandatory.
 - **`project_slug`**: A "slug" string to name the root project directory. This
   will automatically be set as a _slugified_ version of `project_name` if you
-  just leave it blank. E.g. new project directory will be named something like 
+  just leave it blank. E.g. new project directory will be named something like
   "hb-image-analysis".
 - **`app_name`**: The main Python module name. This will also automatically be
   set as a proper "Python valid" name from the `project_name` if you want to
-  leave it blank. E.g. Python app root module will be named something like 
+  leave it blank. E.g. Python app root module will be named something like
   `image_analysis`.
 - **`project_short_description`**: Brief description of what is the purpose of
   the application.
 - **`github_codeowners`**: A list of GitHub users that will own the repository.
-  This sets up a `CODEOWNERS` file which sets the given users or teams as the 
-  default reviewers. They must be given relevant permissions over the 
+  This sets up a `CODEOWNERS` file which sets the given users or teams as the
+  default reviewers. They must be given relevant permissions over the
   repository.
   Defaults to `Agreena-ApS/data-engineering` GitHub team. If you wish to change
   it, please add the GH users or team names separated by commas (`,`).
 - **`python_package`**: Whether to include Python packaging metadata files (`y`)
-  or not (`n`). This will allow the application to be installed as a Python 
-  package with `pip`. Defaults to `y`. 
+  or not (`n`). This will allow the application to be installed as a Python
+  package with `pip`. Defaults to `y`.
 - **`settings_management`**: Whether a Pydantic settings management class should
   be generated (`y`) or not (`n`) as part of the Python codebase bootstrap.
   Defaults to `y`.
 - **`logging_config`**: Whether a basic Python logging configuration dictionary
-  should be generated (`y`) or not (`n`) as part of the Python codebase 
+  should be generated (`y`) or not (`n`) as part of the Python codebase
   bootstrap. Defaults to `y`.
 - **`docker_enabled`**: Whether a basic Dockerfile to create a container image
   for the project should be generated (`y`) or not (`n`). Defaults to `y`.
 - **`freeze_requirements`**: Whether tools to pin requirements files with
-  `pip-tools` should be included (`y`) or not (`n`). Defaults to `y`. 
+  `pip-tools` should be included (`y`) or not (`n`). Defaults to `y`.
   This is only used if `python_package` is set to `y`.
 - **`circle_ci_config`**: Whether a Circle CI YAML configuration file should be
   generated or not, and what workflow should have. There are 3 options here:
@@ -123,6 +123,8 @@ is a reference of them:
   2. `CI-CD`: Generate CircleCI configuration, with full CI/CD development. Your
   Git PRs are merged directly into `main` and both Staging and Production
   deployments are done from there.
-  3. `none`: Don't generate CircleCI configuration at all.
+  3. `airflow-task` this acts like the CI-CD option, but lets you deploy to
+  `staging` from the branch and to `prod` from `main`.
+  4. `none`: Don't generate CircleCI configuration at all.
 - **`code_qa`**: The code QA / linter tool to be used in the project. There are
   currently 3 choices: `pylint`, `flake8`, and `ruff`. Defaults to `pylint`.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,6 @@
     "logging_config": "y",
     "docker_enabled": "y",
     "freeze_requirements": "y",
-    "circle_ci_config": ["trunk", "CI-CD", "none"],
+    "circle_ci_config": ["trunk", "CI-CD", "airflow-task", "none"],
     "code_qa": ["pylint", "flake8", "ruff"]
 }

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -95,6 +95,29 @@ workflows:
           test-tool-args: |
             --verbose
 
+      {% if cookiecutter.circle_ci_config == "airflow-task" %}
+      # Staging
+      - hold:
+          name: hold-staging
+          type: approval
+          requires:
+            - code-qa
+            - test
+            - build
+          filters:
+            branches:
+              ignore: main
+      - push-docker-image:
+          name: push-docker-image-staging
+          env: staging
+          requires:
+            - hold-staging
+          context:
+            - gcp-secrets
+          filters:
+            branches:
+              ignore: main
+      {% else %}
       # Staging
       - push-docker-image:
           name: push-docker-image-staging
@@ -108,9 +131,11 @@ workflows:
           filters:
             branches:
               only: {% if cookiecutter.circle_ci_config == "trunk" %}develop{% elif cookiecutter.circle_ci_config == "CI-CD" %}main{% endif %}
+      {% endif %}
 
       # Production
-      - hold-production:
+      - hold:
+          name: hold-production
           type: approval
           requires:
             - code-qa

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     docker:
       - image: cimg/python:3.10
     environment:
-      IMAGE_NAME: eu.gcr.io/hummingbird-technologies/platform/{{cookiecutter.project_slug}}
+      IMAGE_NAME: eu.gcr.io/hummingbird-technologies/{%- if cookiecutter.circle_ci_config == "airflow-task" -%}tasks{%- else -%}platform{%- endif -%}/{{cookiecutter.project_slug}}
     resource_class: small
 
   tests-runner:
@@ -94,7 +94,6 @@ workflows:
           cov: {{cookiecutter.app_name}}
           test-tool-args: |
             --verbose
-
       {% if cookiecutter.circle_ci_config == "airflow-task" %}
       # Staging
       - hold:
@@ -132,7 +131,6 @@ workflows:
             branches:
               only: {% if cookiecutter.circle_ci_config == "trunk" %}develop{% elif cookiecutter.circle_ci_config == "CI-CD" %}main{% endif %}
       {% endif %}
-
       # Production
       - hold:
           name: hold-production

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -102,6 +102,7 @@ workflows:
           requires:
             - code-qa
             - test
+            - build
           context:
             - gcp-secrets
           filters:
@@ -109,11 +110,12 @@ workflows:
               only: {% if cookiecutter.circle_ci_config == "trunk" %}develop{% elif cookiecutter.circle_ci_config == "CI-CD" %}main{% endif %}
 
       # Production
-      - hold:
+      - hold-production:
           type: approval
           requires:
             - code-qa
             - test
+            - build
           filters:
             branches:
               only: main
@@ -121,7 +123,7 @@ workflows:
           name: push-docker-image-prod
           env: prod
           requires:
-            - hold
+            - hold-production
           context:
             - gcp-secrets
           filters:


### PR DESCRIPTION
## Description
This PR does 2 main things:
- Fix the circleci workflow by making the approval step depend on the build one (otherwise we could push without the build to be ready)
- Add an airflow-task workflow style, which lets you push to staging from the branch and to prod from main

<!-- Summary of the changes and the related issue. -->

Jira ticket : [RS-724](https://agreena-aps.atlassian.net/browse/RS-724)

## How Has This Been Tested?
Generated a new test project locally with the `airflow-task` option to verify that everything works as expected

<!-- Remove this section if tests are not relevant. For example, for a documentation change.

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
-->

## Checklist:

- [x] Relevant README documentation has been updated


[RS-724]: https://agreena-aps.atlassian.net/browse/RS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ