### PR TITLE
Bump setuptools version in pyproject

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,6 +1,6 @@
 {%- if cookiecutter.python_package == 'y' -%}
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 {% endif -%}


### PR DESCRIPTION
## Description

Bump the build backend to `setuptools>=64`. This will allow projects to [work with editable installs in `pip>25`](https://github.com/pypa/pip/issues/11457), as this version of `setuptools` [started supporting PEP660](https://setuptools.pypa.io/en/latest/history.html#id340).

## How Has This Been Tested?

N/A

## Checklist:

- [ ] Relevant README documentation has been updated
