### PR TITLE
move to pyproject.toml and add codeqa workflow

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -1,0 +1,59 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python Code QA Checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
+
+permissions:
+  contents: read
+
+jobs:
+  code_qa_tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # TODO Use a composite action to deduplicate and split to separate jobs?
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Install the package and dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # the repo should support pyproject.toml only
+        pip install -e .[dev]
+    - name: Check formatting with black
+      run: |
+        black --check .
+    - name: Lint with ruff
+      run: |
+        ruff check .
+    - name: Type check with mypy
+      run: |
+        mypy .
+    - name: Test with pytest
+      run: |
+        pytest tests/ \
+          --cov=land_usage_service \
+          --junit-xml=junit/test-results.xml \
+          --cov-report=xml
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@v4
+      with:
+        name: pytest-results
+        path: junit/test-results.xml
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}
+    - name: Upload code coverage results
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-results
+        path: coverage.xml
+      if: ${{ always() }}


### PR DESCRIPTION
## Description

Need to add Github workflow and setup the repo to use `pyproject.toml` as in https://github.com/Agreena-ApS/dlake-fieldstats-client/blob/main/pyproject.toml

Creating a ticket
Jira ticket : [PROJ-](https://agreena-aps.atlassian.net/browse/<PROJ>-)

