### PR TITLE
Bump the ruff pre-commit version

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
 {%- if cookiecutter.code_qa == 'ruff' %}
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -11,9 +11,11 @@ include = '\.pyi?$'
 
 {% if cookiecutter.code_qa == 'ruff' -%}
 [tool.ruff]
-select = ["E", "F", "I"]
 line-length = 100
 target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
 {% endif %}
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Description

Bump the ruff version to avoid formatting issues with the version used in pre-commit.
Use the `ruff` config file format as shown in the [docs](https://docs.astral.sh/ruff/configuration/).

## How Has This Been Tested?

N/A, porting changes from another project.

## Checklist:

- [ ] Relevant README documentation has been updated
